### PR TITLE
updates to fix triage data import into the database

### DIFF
--- a/src/triage.database/Bucket.cs
+++ b/src/triage.database/Bucket.cs
@@ -12,19 +12,14 @@ using System.Threading.Tasks;
 
 namespace triage.database
 {
-    public class Bucket
+    public class Bucket : UniquelyNamedEntity
     {
         public Bucket()
         {
         }
 
         public int BucketId { get; set; }
-
-        [Required]
-        [Index(IsUnique = true)]
-        [StringLength(450)]
-        public string Name { get; set; }
-
+        
         public string BugUrl { get; set; }
     }
 }

--- a/src/triage.database/Dump.cs
+++ b/src/triage.database/Dump.cs
@@ -44,40 +44,20 @@ namespace triage.database
         [ForeignKey("BucketId")]
         public virtual Bucket Bucket { get; set; }
 
-        public void LoadTriageData(IDictionary<string, string> triageData)
+        public void LoadTriageData(TriageData triageData)
         {
-            if (triageData == null) throw new ArgumentNullException("triageData");
-
-            //copy into new dictionary so that we can modify
-            triageData = new Dictionary<string, string>(triageData);
-
-            string val = null;
-
-            //FAILURE_HASH corresponds to the bucket the dump belongs in
-            if (triageData.TryGetValue("FAILURE_HASH", out val))
+            if (this.BucketId != triageData.BucketId)
             {
-                this.Bucket = new Bucket() { Name = val };
-
-                triageData.Remove("FAILURE_HASH");
+                this.BucketId = triageData.BucketId;
             }
 
-            //ALL_THREADS corresponds to the json searialized thread data in the triage data
-            if (triageData.TryGetValue("ALL_THREADS", out val))
+            //for now clear all the threads and insert all new ones
+            //might consider changing to do an in place update if turns out to be a perf issue
+            this.Threads.Clear();
+
+            foreach(var t in triageData.Threads)
             {
-                var threadData = triageData["ALL_THREADS"];
-
-                var threads = DeserializeAllThreads(threadData);
-                
-                //for now clear all the threads and insert all new ones
-                //might consider changing to do an in place update if turns out to be a perf issue
-                this.Threads.Clear();
-
-                foreach(var t in threads)
-                {
-                    this.Threads.Add(t);
-                }
-
-                triageData.Remove("ALL_THREADS");
+                this.Threads.Add(t);
             }
 
             //for now clear all the properties and insert all new ones
@@ -85,54 +65,10 @@ namespace triage.database
             this.Properties.Clear();
 
             //store the remaining properties
-            foreach (var kvp in triageData)
+            foreach (var p in triageData.Properties)
             {
-                this.Properties.Add(new Property() { Name = kvp.Key, Value = kvp.Value });
+                this.Properties.Add(p);
             }
-        }
-
-        private static List<Thread> DeserializeAllThreads(string allThreadsValue)
-        {
-            List<Thread> allThreads = new List<Thread>();
-
-            var serializer = JsonSerializer.CreateDefault();
-
-            var txtReader = new StringReader(allThreadsValue);
-
-            var jsonReader = new JsonTextReader(txtReader);
-
-            var threadObjs = serializer.Deserialize<List<ThreadDeserializerObj>>(jsonReader);
-
-            for(int i = 0; i < threadObjs.Count; i++)
-            {
-                Thread t = new Thread()
-                {
-                    CurrentThread = (i == 0),
-                    Number = threadObjs[i].Index,
-                    OSId = threadObjs[i].Osid
-                };
-
-                for(int j = 0; j < threadObjs[i].Frames.Count; j++)
-                {
-                    var splitFrame = threadObjs[i].Frames[j].Split(new char[] { '!' }, 2);
-
-                    if (splitFrame.Length == 2)
-                    {
-                        t.Frames.Add(new Frame() { Index = j, Module = new Module() { Name = splitFrame[0] }, Routine = new Routine() { Name = splitFrame[1] } });
-                    }
-                }
-
-                allThreads.Add(t);
-            }
-
-            return allThreads;
-        }
-
-        private class ThreadDeserializerObj
-        {
-            public string Osid = null;
-            public int Index = 0;
-            public List<string> Frames = null;
         }
     }
 }

--- a/src/triage.database/Module.cs
+++ b/src/triage.database/Module.cs
@@ -7,13 +7,8 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace triage.database
 {
-    public class Module
+    public class Module : UniquelyNamedEntity
     {
         public int ModuleId { get; set; }
-
-        [Required]
-        [Index(IsUnique = true)]
-        [StringLength(450)]
-        public string Name { get; set; }
     }
 }

--- a/src/triage.database/Routine.cs
+++ b/src/triage.database/Routine.cs
@@ -8,13 +8,8 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace triage.database
 {
-    public class Routine
+    public class Routine : UniquelyNamedEntity
     {
         public int RoutineId { get; set; }
-
-        [Required]
-        [Index(IsUnique = true)]
-        [StringLength(450)]
-        public string Name { get; set; }
     }
 }

--- a/src/triage.database/TriageData.cs
+++ b/src/triage.database/TriageData.cs
@@ -1,0 +1,113 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace triage.database
+{
+    public class TriageData
+    {
+        public int? BucketId { get { return this.Bucket?.BucketId; } }
+        public Bucket Bucket { get; set; }
+
+        public IList<Thread> Threads { get; set; } = new List<Thread>();
+
+        public IList<Property> Properties { get; set; } = new List<Property>();
+
+        public static TriageData FromDictionary(Dictionary<string, string> triageData)
+        {
+            if (triageData == null) throw new ArgumentNullException("triageData");
+
+            var data = new TriageData();
+
+            data.LoadFromStringDictionary(triageData);
+
+            return data;
+        }
+
+        private void LoadFromStringDictionary(Dictionary<string, string> triageData)
+        {
+            //copy into new dictionary so that we can modify
+            triageData = new Dictionary<string, string>(triageData);
+
+            string val = null;
+
+            //FAILURE_HASH corresponds to the bucket the dump belongs in
+            if (triageData.TryGetValue("FAILURE_HASH", out val))
+            {
+                this.Bucket = new Bucket() { Name = val };
+
+                triageData.Remove("FAILURE_HASH");
+            }
+
+            //ALL_THREADS corresponds to the json searialized thread data in the triage data
+            if (triageData.TryGetValue("ALL_THREADS", out val))
+            {
+                var threadData = triageData["ALL_THREADS"];
+
+                var threads = DeserializeAllThreads(threadData);
+                
+                foreach (var t in threads)
+                {
+                    this.Threads.Add(t);
+                }
+
+                triageData.Remove("ALL_THREADS");
+            }
+            
+            //store the remaining properties
+            foreach (var kvp in triageData)
+            {
+                this.Properties.Add(new Property() { Name = kvp.Key, Value = kvp.Value });
+            }
+        }
+
+
+        private static List<Thread> DeserializeAllThreads(string allThreadsValue)
+        {
+            List<Thread> allThreads = new List<Thread>();
+
+            var serializer = JsonSerializer.CreateDefault();
+
+            var txtReader = new StringReader(allThreadsValue);
+
+            var jsonReader = new JsonTextReader(txtReader);
+
+            var threadObjs = serializer.Deserialize<List<ThreadDeserializerObj>>(jsonReader);
+
+            for (int i = 0; i < threadObjs.Count; i++)
+            {
+                Thread t = new Thread()
+                {
+                    CurrentThread = (i == 0),
+                    Number = threadObjs[i].Index,
+                    OSId = threadObjs[i].Osid
+                };
+
+                for (int j = 0; j < threadObjs[i].Frames.Count; j++)
+                {
+                    var splitFrame = threadObjs[i].Frames[j].Split(new char[] { '!' }, 2);
+
+                    if (splitFrame.Length == 2)
+                    {
+                        t.Frames.Add(new Frame() { Index = j, Module = new Module() { Name = splitFrame[0] }, Routine = new Routine() { Name = splitFrame[1] } });
+                    }
+                }
+
+                allThreads.Add(t);
+            }
+
+            return allThreads;
+        }
+
+        private class ThreadDeserializerObj
+        {
+            public string Osid = null;
+            public int Index = 0;
+            public List<string> Frames = null;
+        }
+    }
+}

--- a/src/triage.database/TriageDb.cs
+++ b/src/triage.database/TriageDb.cs
@@ -42,6 +42,10 @@ namespace triage.database
 
             return dump.DumpId;
         }
+        public static async Task UpdateDumpTriageInfo(int dumpId, Dictionary<string, string> triageData)
+        {
+            await UpdateDumpTriageInfo(dumpId, TriageData.FromDictionary(triageData));
+        }
 
         public static async Task UpdateDumpTriageInfo(int dumpId, TriageData triageData)
         {
@@ -151,7 +155,7 @@ WITH [BucketHits]([BucketId], [HitCount], [StartTime], [EndTime]) AS
         AND [D].[DumpTime] <= @p1
     GROUP BY [B].[BucketId]
 )
-SELECT [B].*, [H].[HitCount], [H].[StartTime], [H].[EndTime]
+SELECT [B].[BucketId], [B].[Name], [B].[BugUrl], [H].[HitCount], [H].[StartTime], [H].[EndTime]
 FROM [Buckets] AS [B]
 JOIN [BucketHits] AS [H]
     ON [B].[BucketId] = [H].[BucketId]

--- a/src/triage.database/TriageDb.cs
+++ b/src/triage.database/TriageDb.cs
@@ -6,6 +6,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -42,32 +43,125 @@ namespace triage.database
             return dump.DumpId;
         }
 
-        public static async Task UpdateDumpTriageInfo(int dumpId, Dictionary<string, string> triageData)
+        public static async Task UpdateDumpTriageInfo(int dumpId, TriageData triageData)
         {
             if (triageData == null) throw new ArgumentNullException("triageData");
+
+            Dump dump = null;
 
             using (var context = new TriageDbContext(s_connStr))
             {
                 //find the dump to update
-                var dump = await context.Dumps.FindAsync(dumpId);
+                dump = await context.Dumps.FindAsync(dumpId);
 
                 if(dump == null)
                 {
                     throw new ArgumentException($"Could not update dump.  No dump was found with id {dumpId}", "dumpId");
                 }
 
-                dump.LoadTriageData(triageData);
+                await UpdateUniquelyNamedEntitiesAsync(context, triageData);
 
+                dump.LoadTriageData(triageData);
+            
                 await context.SaveChangesAsync();
             }
         }
-        
-        private const string BUCKET_DATA = @"SELECT * FROM [Buckets]";
+
+        private static async Task UpdateUniquelyNamedEntitiesAsync(TriageDbContext context, TriageData triageData)
+        {
+            //add or update the bucket if it exists
+            if (triageData.Bucket != null && triageData.Bucket.BucketId == 0)
+            {
+                triageData.Bucket = await GetUniquelyNamedEntityAsync(context, context.Buckets, triageData.Bucket);
+                
+            }
+
+            var addedModules = triageData.Threads.Where(t => t.ThreadId == 0).SelectMany(t => t.Frames).Select(f => f.Module).Where(m => m.ModuleId == 0).OrderBy(m => m.Name).ToArray();
+
+            for (int i = 0; i < addedModules.Length; i++)
+            {
+                if (i > 0 && addedModules[i].Name == addedModules[i - 1].Name)
+                {
+                    addedModules[i].ModuleId = addedModules[i - 1].ModuleId;
+                }
+                else
+                {
+                    addedModules[i].ModuleId = (await GetUniquelyNamedEntityAsync(context, context.Modules, addedModules[i])).ModuleId;
+                }
+            }
+            
+            var addedRoutines = triageData.Threads.Where(t => t.ThreadId == 0).SelectMany(t => t.Frames).Select(f => f.Routine).Where(r => r.RoutineId == 0).OrderBy(r => r.Name).ToArray();
+
+            for (int i = 0; i < addedRoutines.Length; i++)
+            {
+                if (i > 0 && addedRoutines[i].Name == addedRoutines[i - 1].Name)
+                {
+                    addedRoutines[i].RoutineId = addedRoutines[i - 1].RoutineId;
+
+                }
+                else
+                {
+                    addedRoutines[i].RoutineId = (await GetUniquelyNamedEntityAsync(context, context.Routines, addedRoutines[i])).RoutineId;
+                }
+                
+            }
+
+            foreach(var frame in triageData.Threads.SelectMany(t => t.Frames))
+            {
+                frame.ModuleId = frame.Module.ModuleId;
+
+                frame.Module = null;
+
+                frame.RoutineId = frame.Routine.RoutineId;
+
+                frame.Routine = null;
+            }
+        }
+
+        private static async Task<T> GetUniquelyNamedEntityAsync<T>(TriageDbContext context, IDbSet<T> set, T entity) where T : UniquelyNamedEntity
+        {
+            if(entity.Name.Length > 450)
+            {
+                entity.Name = entity.Name.Substring(0, 450);
+            }
+
+            T tempEntity = await set.FirstOrDefaultAsync(e => e.Name == entity.Name);
+
+            if(tempEntity != null)
+            {
+                return tempEntity;
+            }
+
+            set.Add(entity);
+
+            await context.SaveChangesAsync();
+
+            return entity;
+
+        }
+
+        private const string BUCKET_DATA_QUERY = @"
+WITH [BucketHits]([BucketId], [HitCount], [StartTime], [EndTime]) AS
+(
+    SELECT [B].[BucketId] AS [BucketId], COUNT([D].[DumpId]) AS [HitCount], @p0 AS [StartTime], @p1 AS [EndTime]
+    FROM [Dumps] [D]
+    JOIN [Buckets] [B]
+        ON [D].[BucketId] = [B].[BucketId]
+        AND [D].[DumpTime] >= @p0
+        AND [D].[DumpTime] <= @p1
+    GROUP BY [B].[BucketId]
+)
+SELECT [B].*, [H].[HitCount], [H].[StartTime], [H].[EndTime]
+FROM [Buckets] AS [B]
+JOIN [BucketHits] AS [H]
+    ON [B].[BucketId] = [H].[BucketId]
+";
+
         public static async Task<IEnumerable<BucketData>> GetBucketDataAsync(DateTime start, DateTime end)
         {
             using (var context = new TriageDbContext(s_connStr))
             {
-                var data = context.Database.SqlQuery<BucketData>(BUCKET_DATA, start, end);
+                var data = context.Database.SqlQuery<BucketData>(BUCKET_DATA_QUERY, start, end);
                 var returnValue = await data.ToArrayAsync();
                 return returnValue;
             }

--- a/src/triage.database/TriageDbContext.cs
+++ b/src/triage.database/TriageDbContext.cs
@@ -28,16 +28,6 @@ namespace triage.database
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<Module>().MapToStoredProcedures(s => 
-                s.Insert(u => u.HasName("Module_Insert")
-                                .Parameter(r => r.Name, "name")));
-            modelBuilder.Entity<Routine>().MapToStoredProcedures(s =>
-                s.Insert(u => u.HasName("Routine_Insert")
-                                .Parameter(r => r.Name, "name")));
-            modelBuilder.Entity<Bucket>().MapToStoredProcedures(s =>
-                s.Insert(u => u.HasName("Bucket_Insert")
-                                .Parameter(r => r.Name, "name")));
         }
     }
 }

--- a/src/triage.database/UniquelyNamedEntity.cs
+++ b/src/triage.database/UniquelyNamedEntity.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace triage.database
+{
+    public class UniquelyNamedEntity
+    {
+        [Required]
+        [Index(IsUnique = true)]
+        [StringLength(450)]
+        public string Name { get; set; }
+    }
+}

--- a/src/triage.database/install/TriageDbInitializer.cs
+++ b/src/triage.database/install/TriageDbInitializer.cs
@@ -15,9 +15,6 @@ namespace triage.database.install
     {
         public override void InitializeDatabase(TriageDbContext context)
         {
-            //call install scripts
-            context.Database.ExecuteSqlCommand(InstallScripts.Create_Module_Insert);
-            context.Database.ExecuteSqlCommand(InstallScripts.Create_Routine_Insert);
         }
     }
 }

--- a/src/triage.database/triage.database.csproj
+++ b/src/triage.database/triage.database.csproj
@@ -70,8 +70,10 @@
     <Compile Include="Routine.cs" />
     <Compile Include="Module.cs" />
     <Compile Include="Thread.cs" />
+    <Compile Include="TriageData.cs" />
     <Compile Include="TriageDb.cs" />
     <Compile Include="TriageDbContext.cs" />
+    <Compile Include="UniquelyNamedEntity.cs" />
     <!--Compile Include="Properties\AssemblyInfo.cs" /-->
   </ItemGroup>
   <ItemGroup>

--- a/src/triage/App.config
+++ b/src/triage/App.config
@@ -1,6 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
-    </startup>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  </startup>
+  <connectionStrings>
+    <add name="TriageDbContext" connectionString="Data Source=(localdb)\MSSQLLocalDb;Initial Catalog=TriageDb;Integrated Security=True" providerName="System.Data.SqlClient" />
+  </connectionStrings>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="TriageDbContext" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
 </configuration>

--- a/src/triage/Program.cs
+++ b/src/triage/Program.cs
@@ -2,11 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using triage.database;
 
 namespace triage
 {
@@ -14,6 +17,58 @@ namespace triage
     {
         private static void Main(string[] args)
         {
+            TriageDb.Init("TriageDbContext");
+
+            List<Dump> dumps = new List<Dump>();
+            foreach (var triagePath in Directory.EnumerateFiles(@"h:\temp\triagedata"))
+            {
+
+                Dump d = new Dump() { DisplayName = Path.GetFileNameWithoutExtension(triagePath), DumpPath = triagePath, Origin = "TestData", DumpTime = DateTime.Now };
+
+                dumps.Add(d);
+
+                d.DumpId = TriageDb.AddDumpAsync(d).GetAwaiter().GetResult();
+            }
+
+
+            foreach(var d in dumps)
+            {
+                try
+                {
+                    Dictionary<string, string> dict = DeserializeTriageJson(d.DumpPath);
+
+                    var triageData = TriageData.FromDictionary(dict);
+
+                    TriageDb.UpdateDumpTriageInfo(d.DumpId, triageData).GetAwaiter().GetResult();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Dump {d.DisplayName} failed to update triage info.");
+                    Console.WriteLine(e);
+                }
+            }
+        }
+
+
+        public static Dictionary<string,string> DeserializeTriageJson(string path)
+        {
+            Dictionary<string, string> config = null;
+
+            // Deserialize the RunConfiguration
+            JsonSerializer serializer = JsonSerializer.CreateDefault();
+
+            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read))
+            {
+                using (StreamReader reader = new StreamReader(fs))
+                {
+                    JsonTextReader jReader = new JsonTextReader(reader);
+
+                    // Call the Deserialize method to restore the object's state.
+                    config = serializer.Deserialize<Dictionary<string, string>>(jReader);
+                }
+            }
+
+            return config;
         }
     }
 }

--- a/src/triage/packages.config
+++ b/src/triage/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+</packages>

--- a/src/triage/triage.csproj
+++ b/src/triage/triage.csproj
@@ -36,8 +36,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework">
+      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer">
+      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -52,6 +65,13 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\triage.database\triage.database.csproj">
+      <Project>{fc9c2bba-10ff-4cc0-a4c5-9d5ac5cc033b}</Project>
+      <Name>triage.database</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="..\dir.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
 This introduces a new class TriageData and a breaking change to the triagedb interface

public static async Task UpdateDumpTriageInfo(int dumpId, Dictionary<string, string> triageData) 

changes to:
public static async Task UpdateDumpTriageInfo(int dumpId, TriageData triageData)

To get the instance of TriageData to pass into UpdateDumpTriageInfo call TriageData.FromDictionary(Dictionary<string,string> triageData).

Example:

```
                Dictionary<string, string> dict = DeserializeTriageJson(triageJson);

                var triageData = TriageData.FromDictionary(dict);

                TriageDb.UpdateDumpTriageInfo(dumpId, triageData).GetAwaiter().GetResult();
```
