### PR TITLE
updating triage.ini to ignore libstdc++.so.6

### DIFF
--- a/src/triage.python/triage.ini
+++ b/src/triage.python/triage.ini
@@ -1,7 +1,8 @@
 ;
-; OS Modules to ignore
+; OS / tooling Modules to ignore
 ;
 libc.so.6!*=ignore
+libstdc++.so.6!*=ignore
 libpthread.so.0!*=ignore
 libicuuc.so.52!*=ignore
 libicui18n.so.52!*=ignore


### PR DESCRIPTION
this is a fix for issue https://github.com/Microsoft/dotnet-reliability/issues/44
