### PR TITLE
update triage.ini to ignore helper frames calling into managed code

### DIFF
--- a/src/triage.python/triage.ini
+++ b/src/triage.python/triage.ini
@@ -42,6 +42,8 @@ libcoreclr.so!IL_Rethrow=ignore
 ;
 ; Helper frames to ignore
 ;
+libcoreclr.so!MethodDescCallSite::CallTargetWorker
+libcoreclr.so!CallDescrWorker
 libcoreclr.so!PreStubWorker=ignore
 libcoreclr.so!ThePreStub=ignore
 


### PR DESCRIPTION

this is a partial fix for issue https://github.com/Microsoft/dotnet-reliability/issues/43
