### PR TITLE
updates to triagedb to delete property, frame, and thread entities before removing them from dumps

### DIFF
--- a/src/triage.database/TriageDb.cs
+++ b/src/triage.database/TriageDb.cs
@@ -64,7 +64,14 @@ namespace triage.database
                 }
 
                 await UpdateUniquelyNamedEntitiesAsync(context, triageData);
+                
+                //remove all the dump properties from the context before updating
+                //this is needed because property has a required FK to dumpId so
+                //properties without an associated dump are not allowed
+                context.Properties.RemoveRange(dump.Properties);
 
+                dump.Properties.Clear();
+                
                 dump.LoadTriageData(triageData);
             
                 await context.SaveChangesAsync();

--- a/src/triage.database/TriageDb.cs
+++ b/src/triage.database/TriageDb.cs
@@ -70,8 +70,16 @@ namespace triage.database
                 //properties without an associated dump are not allowed
                 context.Properties.RemoveRange(dump.Properties);
 
-                dump.Properties.Clear();
-                
+                var frames = dump.Threads.SelectMany(t => t.Frames).ToArray();
+
+                context.Frames.RemoveRange(frames);
+
+                context.Threads.RemoveRange(dump.Threads);
+
+                await context.SaveChangesAsync();
+
+                await context.Entry<Dump>(dump).ReloadAsync();
+
                 dump.LoadTriageData(triageData);
             
                 await context.SaveChangesAsync();


### PR DESCRIPTION
this fixes an issue in UpdateDumpTriageData where db updates were failing due to FK constraints.