### PR TITLE
[In progress] Update Properties work

### DIFF
--- a/src/dumpling-service/dumpling.web/Controllers/DumplingServiceController.cs
+++ b/src/dumpling-service/dumpling.web/Controllers/DumplingServiceController.cs
@@ -11,6 +11,9 @@ using System.Threading.Tasks;
 using System.Web.Http;
 using triage.database;
 using DumplingLib;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace dumplingWeb.Controllers
 {
@@ -36,6 +39,15 @@ namespace dumplingWeb.Controllers
             await DumplingEventHub.FireEvent(new WebAPIGetStatusEvent());
 
             return await StateTableController.GetState(new StateTableIdentifier() { Owner = owner, DumplingId = dumplingid });
+        }
+
+        [Route("dumpling/triageinfo/add/{dumplingid}")]
+        [HttpPut]
+        public async Task AddTriageInfo(int dumplingid, [FromBody]JToken jsonTriageInfo)
+        {
+            var kvData = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonTriageInfo.ToString());
+
+            await TriageDb.UpdateDumpTriageInfo(dumplingid, kvData);
         }
 
         [Route("dumpling/redumpling/{owner}/{dumplingid}/{os}")]


### PR DESCRIPTION
- adding post method to update triage properties for a dump id

@schaabs, the UpdateTriageInfo is causing dumps to be deleted from the main page (i.e. if I try to add a property to dump '1234' then '1234' becomes deleted from the table.
