### PR TITLE
Minor Updates 

### DIFF
--- a/src/stress.execution/project.json
+++ b/src/stress.execution/project.json
@@ -1,9 +1,9 @@
 {
 
   "dependencies": {
-    "System.Diagnostics.Process": "4.1.0-rc2-23923",
+    "System.Diagnostics.Process": "4.1.0",
     "xunit.core": "2.1.0",
-    "Microsoft.NETCore": "5.0.1-rc2-23923",
+    "NETStandard.Library": "1.6.0",
   },
   "frameworks": {
     "netstandard1.3": {

--- a/src/triage.database/TriageDb.cs
+++ b/src/triage.database/TriageDb.cs
@@ -198,17 +198,15 @@ namespace triage.database
         private const string BUCKET_DATA_QUERY = @"
 WITH [BucketHits]([BucketId], [HitCount], [StartTime], [EndTime]) AS
 (
-    SELECT [B].[BucketId] AS [BucketId], COUNT([D].[DumpId]) AS [HitCount], @p0 AS [StartTime], @p1 AS [EndTime]
+    SELECT [D].[BucketId] AS [BucketId], COUNT([D].[DumpId]) AS [HitCount], @p0 AS [StartTime], @p1 AS [EndTime]
     FROM [Dumps] [D]
-    JOIN [Buckets] [B]
-        ON [D].[BucketId] = [B].[BucketId]
-        AND [D].[DumpTime] >= @p0
+	WHERE [D].[DumpTime] >= @p0
         AND [D].[DumpTime] <= @p1
-    GROUP BY [B].[BucketId]
+    GROUP BY [D].[BucketId]
 )
 SELECT [B].[BucketId], [B].[Name], [B].[BugUrl], [H].[HitCount], [H].[StartTime], [H].[EndTime]
 FROM [Buckets] AS [B]
-JOIN [BucketHits] AS [H]
+RIGHT OUTER JOIN [BucketHits] AS [H]
     ON [B].[BucketId] = [H].[BucketId]
 ORDER BY [H].[HitCount] DESC
 ";

--- a/src/triage.python/dumpling.py
+++ b/src/triage.python/dumpling.py
@@ -229,6 +229,10 @@ if __name__ == '__main__':
         if args.displayname == None:
             filename = os.path.basename(os.path.abspath(args.zipfile))
             args.displayname = os.path.splitext(filename)[0]
+            args.displayname = args.displayname.replace('.', '_')
+        if '.' in args.displayname:
+            print 'WARNING: the character \'.\' is not allowed in the display name replacing with \'_\''
+            args.displayname = args.displayname.replace('.', '_')
         dumplingid = DumplingService.UploadZip(os.path.abspath(args.zipfile), args.user, args.distro, args.displayname)
         if not args.suppresstriage:
             DumplingService.UploadTriageInfo(dumplingid, get_client_triage_data())
@@ -238,8 +242,12 @@ if __name__ == '__main__':
         print 'unpacking core dump zip to: ' + args.unpackdir
         unpack(args.zipfile, args.unpackdir)
     elif args.command == 'download':
-        if args.unpackdir == None:
-            args.unpackdir = os.path.join(os.getcwd(), 'dumpling.%.7f'%time.time())
+        if args.unpackdir == None:                                                    
+            if args.dumpid is not None:
+                args.unpackdir = os.path.join(os.getcwd(), 'dumpling.%s'%args.dumpid)
+            else:
+                args.unpackdir = os.path.join(os.getcwd(), 'dumpling.%.7f'%time.time())
+        args.unpackdir = args.unpackdir.replace('.', '_')
         if args.zipfile == None:
             args.zipfile = args.unpackdir + '.zip'
         if args.dumpid is not None:


### PR DESCRIPTION
updating stress.execution to reference .NETCore 1.0 RTM version 
updating TriageDb BUCKET_DATA_QUERY to include untriaged items

@bryanar please take a look at the changes to BUCKET_DATA_QUERY, this will change behaviour as there might now be BucketData objects with null name