### PR TITLE
Fix Linux distro detection

### DIFF
--- a/src/triage.python/dumpling.py
+++ b/src/triage.python/dumpling.py
@@ -222,7 +222,7 @@ if __name__ == '__main__':
             args.user = getpass.getuser()
         args.user = args.user.lower()
         if args.distro == None:
-            if platform.platform().lower() == 'linux':
+            if platform.system().lower() == 'linux':
                 args.distro = platform.dist()[0].lower()
             else:
                 args.distro = 'win'


### PR DESCRIPTION
Dumps from Linux are being miscategorized as Windows ("win"). The problem seems to be that the dumpling script compares the result of `platform.platform()` to "linux" when in fact that function returns a long string with a lot of other information. `platform.system()` returns things like `Linux`, `Windows`, `Darwin`, and so on, so that's what should be used here.

@bryanar @schaabs 