### PR TITLE
adding selfdestruct to stress mixes

### DIFF
--- a/src/stress.codegen/LoadSuiteGenerator.cs
+++ b/src/stress.codegen/LoadSuiteGenerator.cs
@@ -41,6 +41,7 @@ namespace stress.codegen
                         TestPatternType = typeof(RandomTestPattern),                          //Type.GetType(loadTestConfig.TestPattern),
                         WorkerStrategyType = typeof(DedicatedThreadWorkerStrategy),           //Type.GetType(loadTestConfig.WorkerStrategy),
                         WorkerCount = loadTestConfig.NumWorkers,
+                        SelfDestruct = loadTestConfig.SelfDestruct,
                         EnvironmentVariables = loadTestConfig.EnvironmentVariables,
                         SuiteConfig = config,
                         Seed = rand.Next(),

--- a/src/stress.codegen/LoadTestConfig.cs
+++ b/src/stress.codegen/LoadTestConfig.cs
@@ -33,6 +33,9 @@ namespace stress.codegen
         // The execution strategy for this load test
         public string WorkerStrategy;
 
+        //if true the load test will exit with unhandled exception to force dump collection
+        public bool SelfDestruct;
+
         public Dictionary<string, string> EnvironmentVariables;
 
         public LoadTestConfig()

--- a/src/stress.codegen/LoadTestInfo.cs
+++ b/src/stress.codegen/LoadTestInfo.cs
@@ -37,8 +37,10 @@ namespace stress.codegen
 
         public int WorkerCount { get; set; }
 
+        public bool SelfDestruct { get; set; }
+
         public string SourceDirectory { get; set; }
-        
+
         public IEnumerable<UnitTestInfo> UnitTests { get; set; }
 
         public IList<SourceFileInfo> SourceFiles { get; private set; }

--- a/src/stress.codegen/ProgramSourceFileGenerator.cs
+++ b/src/stress.codegen/ProgramSourceFileGenerator.cs
@@ -23,8 +23,15 @@ using stress.execution;
 
 namespace stress.generated
 {{
+    public class SelfDestructException : Exception
+    {{
+        public SelfDestructException() : base(""The operation self destructed."") {{ }}
+    }}
+    
     public static class Program
     {{
+        static private bool s_selfdestruct = {loadTest.SelfDestruct.ToString().ToLower()};
+
         public static void Main(string[] args)
         {{
             TimeSpan duration = TimeSpan.Parse(""{loadTest.Duration.ToString()}"");
@@ -32,6 +39,11 @@ namespace stress.generated
             CancellationTokenSource tokenSource = new CancellationTokenSource(duration);
             
             LoadTestClass.LoadTestMethod(tokenSource.Token);
+
+            if(s_selfdestruct)
+            {{
+                throw new SelfDestructException();
+            }}
         }}
     }}
 }}

--- a/test/suiteconfig/smoketest.suite.json
+++ b/test/suiteconfig/smoketest.suite.json
@@ -13,6 +13,20 @@
         "COMPlus_DebugBreakOnAssert": "1",
         "COMPlus_AssertOnFailFast": "1"
       }
+    },
+    {
+      "TestCount": 10,
+      "NumTests": 10,
+      "Duration": "00:01:30",
+      "NumWorkers": 8,
+      "TestPattern": "stress.execution.RandomTestPattern, stress.execution, Version=1.0.0, Culture=neutral, PublicKeyToken=null",
+      "LoadPattern": "stress.execution.StaticLoadPattern, stress.execution, Version=1.0.0, Culture=neutral, PublicKeyToken=null",
+      "WorkerStrategy": "stress.execution.DedicatedThreadWorkerStrategy, stress.execution, Version=1.0.0, Culture=neutral, PublicKeyToken=null",
+      "SelfDestruct": true,
+      "EnvironmentVariables": {
+        "COMPlus_DebugBreakOnAssert": "1",
+        "COMPlus_AssertOnFailFast": "1"
+      }
     }
   ]
 }


### PR DESCRIPTION
added ability to specify that stress mixes self destruct through suite config to allow for easy testing of dump collection